### PR TITLE
Issue #1. Critical Push Notifications.

### DIFF
--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -63,9 +63,8 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
                                                 name:UIApplicationDidBecomeActiveNotification
                                               object:nil];
 
-    // Cordova Plugin Push issue #1. Define a listener for the UIApplicationDidFinishLaunchingNotification event that will be invoked when the app has  
+    // Define a listener for the UIApplicationDidFinishLaunchingNotification event that will be invoked when the app has  
     // finished launching and ready to present any windows to the user (according to the lifecycle of the iOS app).
-    // https://github.com/TransformativeMed/cordova-plugin-push/issues/1
     // Helpful documentation about lifecycle: https://medium.com/@theiOSzone/briefly-about-the-ios-application-lifecycle-92f0c830b754
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(getDataNotificationLaunchedApp:)
@@ -77,9 +76,7 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
     return [self pushPluginSwizzledInit];
 }
 
-// Cordova Plugin Push issues #1. This code will be called immediately after UIApplicationDidFinishLaunchingNotification event once the app is opened/loaded correctly.
-// https://github.com/TransformativeMed/cordova-plugin-push/issues/1
-// 
+// This code will be called immediately after UIApplicationDidFinishLaunchingNotification event once the app is opened/loaded correctly.
 - (void)getDataNotificationLaunchedApp:(NSNotification *)notification {
     
     // Check if the app has the following option permissions to display Normal/Critical Push Notifications on screen (sent via APNS), even if the app is on foreground.


### PR DESCRIPTION
## Description
Added an event listener to request permissions to the user once the app is opened, no matter if it was opened by the user or by a tapped push notification.

This will be helpful since we don't need to wait the execution of the "init" method of this plugin to ask access to the user.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Critical Push Notifications](https://github.com/TransformativeMed/cordova-plugin-push/issues/1)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I added this change because the plugin should request the permissions to the user as soon as the user opens the application without having to wait for the business logic of the application. Also, this change was requested time ago by T4M and it has been used that way ever since because we already know the app will use normal and critical notifications.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changes tested in a mobile device with the following specs:
- 16.5.1 iOS version.
- iPhone XR model.

## Screenshots (if appropriate):

https://github.com/TransformativeMed/cordova-plugin-push/assets/12654157/7f2f30cc-7f64-41d2-925b-308779c035b9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
