### PR TITLE
Android changes: Modified behavior of the push notifications and added a new features.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,6 +33,8 @@
       <uses-permission android:name="android.permission.WAKE_LOCK"/>
       <uses-permission android:name="android.permission.VIBRATE"/>
       <uses-permission android:name="${applicationId}.permission.PushHandlerActivity"/>
+      <!-- Permission to get access to the notification policy. It is used in the process to modify the Do Not Disturb settings -->
+      <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY"/>
       <permission android:name="${applicationId}.permission.PushHandlerActivity" android:protectionLevel="signature"></permission>
     </config-file>
 

--- a/src/android/com/adobe/phonegap/push/BackgroundHandlerActivity.kt
+++ b/src/android/com/adobe/phonegap/push/BackgroundHandlerActivity.kt
@@ -81,6 +81,7 @@ class BackgroundHandlerActivity : Activity() {
 
       originalExtras.putBoolean(PushConstants.FOREGROUND, false)
       originalExtras.putBoolean(PushConstants.COLDSTART, !PushPlugin.isActive)
+      originalExtras.putBoolean(PushConstants.TAPPED, false)
       originalExtras.putBoolean(PushConstants.DISMISSED, extras.getBoolean(PushConstants.DISMISSED))
       originalExtras.putString(
         PushConstants.ACTION_CALLBACK,

--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -995,7 +995,6 @@ class FCMService : FirebaseMessagingService() {
     notificationManager: NotificationManager
   ): NotificationCompat.Builder {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      var channelID: String? = null
 
       if (extras != null) {
         channelID = extras.getString(PushConstants.ANDROID_CHANNEL_ID)

--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -208,8 +208,6 @@ class FCMService : FirebaseMessagingService() {
       // Foreground
       extras.putBoolean(PushConstants.FOREGROUND, isInForeground)
 
-      
-
       // if we are in the foreground and forceShow is `false` only send data.
       // By default when a notification is received, its data should include flags indicating whether the app is in the foreground and whether it was pressed.
       val forceShow = pushSharedPref.getBoolean(PushConstants.FORCE_SHOW, false)
@@ -217,16 +215,19 @@ class FCMService : FirebaseMessagingService() {
         Log.d(TAG, "Do Not Force & Is In Foreground")
         extras.putBoolean(PushConstants.COLDSTART, false)
         extras.putBoolean(PushConstants.FOREGROUND, true)
+        extras.putBoolean(PushConstants.TAPPED, false);
         sendExtras(extras)
       } else if (forceShow && isInForeground) {
         Log.d(TAG, "Force & Is In Foreground")
         extras.putBoolean(PushConstants.COLDSTART, false)
         extras.putBoolean(PushConstants.FOREGROUND, true);
+        extras.putBoolean(PushConstants.TAPPED, false);
         showNotificationIfPossible(extras)
       } else {
         Log.d(TAG, "In Background")
         extras.putBoolean(PushConstants.COLDSTART, isActive)
         extras.putBoolean(PushConstants.FOREGROUND, false);
+        extras.putBoolean(PushConstants.TAPPED, false);
         showNotificationIfPossible(extras)
       }
     }
@@ -476,7 +477,7 @@ class FCMService : FirebaseMessagingService() {
       val contentAvailable = it.getString(PushConstants.CONTENT_AVAILABLE)
       val forceStart = it.getString(PushConstants.FORCE_START)
       val badgeCount = extractBadgeCount(extras)
-      
+      val tapped = it.getString(PushConstants.TAPPED)
 
       if (badgeCount >= 0) {
         setApplicationIconBadgeNumber(context, badgeCount)
@@ -492,6 +493,7 @@ class FCMService : FirebaseMessagingService() {
       Log.d(TAG, "contentAvailable=$contentAvailable")
       Log.d(TAG, "forceStart=$forceStart")
       Log.d(TAG, "badgeCount=$badgeCount")
+      Log.d(TAG, "isTapped =$tapped");
 
       val hasMessage = message != null && message.isNotEmpty()
       val hasTitle = title != null && title.isNotEmpty()
@@ -627,7 +629,6 @@ class FCMService : FirebaseMessagingService() {
     /*
      * Notification Sound
      */
-    
     if (soundOption) {
       setNotificationSound(extras, mBuilder)
     }

--- a/src/android/com/adobe/phonegap/push/PushConstants.kt
+++ b/src/android/com/adobe/phonegap/push/PushConstants.kt
@@ -17,6 +17,11 @@ object PushConstants {
   const val OPEN_ALL_GROUP_KEY: String = "open.all.notifications.coresmobile"
   const val OPEN_ALL_NOTIFICATION_ID: Int = 1
   const val CHANGE_DND_FROM_CORES: String = "openDNDsettings"
+  const val REMOVE_NOTIFICATION_FROM_TRAY_BY_NOTIFICATION_ID: String = "removeNotificationFromTray"
+  const val NOTIFICATION_CORES_TYPE: String = "notificationCORESType"
+  const val NOTIFICATION_CRITICAL_CORES_TYPE: String = "critical"
+  const val NOTIFICATION_NORMAL_CORES_TYPE: String = "normal"
+  const val TAPPED: String = "isTapped"
 
   const val COM_ADOBE_PHONEGAP_PUSH: String = "com.adobe.phonegap.push"
   const val REGISTRATION_ID: String = "registrationId"

--- a/src/android/com/adobe/phonegap/push/PushConstants.kt
+++ b/src/android/com/adobe/phonegap/push/PushConstants.kt
@@ -7,6 +7,9 @@ package com.adobe.phonegap.push
  */
 @Suppress("HardCodedStringLiteral")
 object PushConstants {
+ 
+  const val CHANGE_DND_FROM_CORES: String = "openDNDsettings"
+
   const val COM_ADOBE_PHONEGAP_PUSH: String = "com.adobe.phonegap.push"
   const val REGISTRATION_ID: String = "registrationId"
   const val REGISTRATION_TYPE: String = "registrationType"

--- a/src/android/com/adobe/phonegap/push/PushConstants.kt
+++ b/src/android/com/adobe/phonegap/push/PushConstants.kt
@@ -7,7 +7,15 @@ package com.adobe.phonegap.push
  */
 @Suppress("HardCodedStringLiteral")
 object PushConstants {
- 
+  const val CORES_NOTIFICATION_ID_KEY: String = "notification_id"
+  const val BUNDLE_KEY_NOTIFICATIONS_GROUPED_WITH_CONTENT: String = "notificationsGroupedContentList"
+  const val GROUP_KEY: String = "com.transformativemed.coresmobile"
+  const val GROUP_NOTIFICATION_ID: Int = 2
+  const val BUNDLE_KEY_CORES_NOTIFICATION_ID: String = "cores_notification_id"
+  const val BUNDLE_KEY_OPEN_ALL_NOTIFICATIONS: String = "notificationsToOpen"
+  const val BUNDLE_KEY_OPEN_GROUPED_NOTIFICATIONS: String = "openGroupedNotifications"
+  const val OPEN_ALL_GROUP_KEY: String = "open.all.notifications.coresmobile"
+  const val OPEN_ALL_NOTIFICATION_ID: Int = 1
   const val CHANGE_DND_FROM_CORES: String = "openDNDsettings"
 
   const val COM_ADOBE_PHONEGAP_PUSH: String = "com.adobe.phonegap.push"

--- a/src/android/com/adobe/phonegap/push/PushDismissedHandler.kt
+++ b/src/android/com/adobe/phonegap/push/PushDismissedHandler.kt
@@ -1,10 +1,16 @@
 package com.adobe.phonegap.push
 
 import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.util.Log
+import androidx.annotation.RequiresApi
+import org.json.JSONException
+import org.json.JSONObject
 
 /**
  *
@@ -16,15 +22,83 @@ class PushDismissedHandler : BroadcastReceiver() {
     private const val TAG: String = "${PushPlugin.PREFIX_TAG} (PushDismissedHandler)"
   }
 
+  private val LOG_TAG = "Push_DismissedHandler"
+
   /**
    * @param context
    * @param intent
    */
+  @RequiresApi(Build.VERSION_CODES.M)
   override fun onReceive(context: Context, intent: Intent) {
     if (intent.action == PushConstants.PUSH_DISMISSED) {
+
       val notID = intent.getIntExtra(PushConstants.NOT_ID, 0)
+      val extras = intent.extras
+      val fcm = FCMService()
+
       Log.d(TAG, "not id = $notID")
-      FCMService().setNotification(notID, "")
+
+      // Check if the dismissed item was a single notification or the grouper notification.
+      if(notID == PushConstants.GROUP_NOTIFICATION_ID){
+
+        // Since the grouper was dismissed, we need to clear the list of received notifications to be able to display a correct grouper
+        // the next time a new batch of notifications are received.
+        fcm.cleanNotificationList();
+        fcm.cleanCoresNotificationIDList();
+
+      } else {
+
+        // Single notification.
+
+        // When a notification is dismissed by the user, we need to update the list of received notifications that is manually handled in the FCMService class:
+        // - Remove the content of the notification to indicate it was dismissed.
+        fcm.setNotification(notID, "");
+        // - Remove from the list that represents an item within CORES Mobile the notification that was dismissed.
+        try {
+          val coresPayloadJsonString = extras!!.getBundle(PushConstants.PUSH_BUNDLE)!!["coresPayload"].toString()
+          val jsonCoresPayload = JSONObject(coresPayloadJsonString)
+          fcm.removeCoresNotificationIDfromList(jsonCoresPayload.getString("notification_id"))
+        } catch (e: JSONException) {
+          e.printStackTrace()
+        }
+
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        // Check if the notification grouper has enough items to continue in the Notification Drawer, otherwise it should be removed.
+        if (fcm.getCoresNotificationIDlist()!!.size === 0) {
+
+          // Remove the grouper notification from the Notification Drawer.
+          notificationManager.cancel(PushConstants.GROUP_NOTIFICATION_ID)
+        } else {
+
+          // We need to refresh the grouper notification to adjust and display the correct content in the summary text.
+          val activeNotifications = notificationManager.activeNotifications
+
+          // Search the current grouper notification that is displayed in the Notification Drawer.
+          for (statusBarNotification in activeNotifications) {
+            if (statusBarNotification.id == PushConstants.GROUP_NOTIFICATION_ID) {
+              val grouperNotification: Notification = statusBarNotification.notification
+
+              // Refresh the notification grouper to update the summary text (replacing the current notification grouper with a new one but using the same data to
+              // avoid losing the notifications that are currently grouped by it).
+              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                fcm.displayGrouperNotification(
+                  grouperNotification.extras,
+                  context,
+                  grouperNotification.getChannelId(),
+                  notificationManager
+                )
+              }
+              break
+            }
+
+          }
+
+        }
+
+      }
+
     }
+
   }
 }

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.kt
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.kt
@@ -3,11 +3,16 @@ package com.adobe.phonegap.push
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.NotificationManager
+import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.core.app.RemoteInput
+import org.json.JSONException
+import org.json.JSONObject
+import java.util.*
+
 
 /**
  * Push Handler Activity
@@ -18,6 +23,8 @@ class PushHandlerActivity : Activity() {
   companion object {
     private const val TAG: String = "${PushPlugin.PREFIX_TAG} (PushHandlerActivity)"
   }
+
+  var originalExtras: Bundle? = null
 
   /**
    * this activity will be started if the user touches a notification that we own.
@@ -32,6 +39,8 @@ class PushHandlerActivity : Activity() {
     super.onCreate(savedInstanceState)
     Log.v(TAG, "onCreate")
 
+    val fcm = FCMService()
+
     intent.extras?.let { extras ->
       val notId = extras.getInt(PushConstants.NOT_ID, 0)
       val callback = extras.getString(PushConstants.CALLBACK)
@@ -39,10 +48,50 @@ class PushHandlerActivity : Activity() {
       val startOnBackground = extras.getBoolean(PushConstants.START_IN_BACKGROUND, false)
       val dismissed = extras.getBoolean(PushConstants.DISMISSED, false)
 
-      FCMService().setNotification(notId, "")
+      val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+      if(notId == PushConstants.GROUP_NOTIFICATION_ID) {
+
+        // Notification grouper.
+
+        // Since the notification grouper was pressed, we need to remove the items that were grouped and clean the list
+        // of the received notifications to be able to display the next grouper correctly once a new items are received.
+        fcm.cleanCoresNotificationIDList()
+        fcm.cleanNotificationList()
+
+        // Remove the grouper from the Notification Drawer.
+        notificationManager.cancel(PushConstants.GROUP_NOTIFICATION_ID)
+
+      } else {
+
+        // Single notification.
+
+        // Remove from the Notification drawer the pressed notification.
+        notificationManager.cancel(notId)
+
+        // Remove the content of the pressed notification from the list of received notifications.
+        fcm.setNotification(notId, "")
+
+        // Remove from the list that represents an item within CORES Mobile app the item that was pressed.
+        try {
+          val coresPayloadJsonString =
+            intent.extras!!.getBundle(PushConstants.PUSH_BUNDLE)!!["coresPayload"].toString()
+          val jsonCoresPayload = JSONObject(coresPayloadJsonString)
+          fcm.removeCoresNotificationIDfromList(jsonCoresPayload.getString("notification_id"))
+        } catch (e: JSONException) {
+          e.printStackTrace()
+        }
+
+        // Check if the notification grouper has enough items to be displayed.
+        if (fcm.getCoresNotificationIDlist()!!.size === 0) {
+
+          // Remove the notification grouper from the Notification Drawer.
+          notificationManager.cancel(PushConstants.GROUP_NOTIFICATION_ID)
+        }
+
+      }
 
       if (!startOnBackground) {
-        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.cancel(FCMService.getAppName(this), notId)
       }
 
@@ -72,6 +121,34 @@ class PushHandlerActivity : Activity() {
         } else {
           Log.d(TAG, "Don't Want Main Activity")
         }
+
+        // Check if the plugin is ready to be used to send the data to the CORES Mobile app.
+        if (originalExtras != null) {
+          if (PushPlugin.isActive) {
+            PushPlugin.sendExtras(originalExtras)
+          } else {
+
+            // Create a timer to check once the plugin is available.
+            val checkPluginIsReady = Timer()
+
+            // For security reasons, we create a counter to prevent the timer from running indefinitely, running for a maximum of 5 seconds.
+            val maxTimerIterations = 25
+            val currentTimerIteration = intArrayOf(1)
+            checkPluginIsReady.scheduleAtFixedRate(object : TimerTask() {
+              override fun run() {
+                Log.i("CORES Workflows", "Cordova Plugin Push is not ready, trying again.")
+                if (PushPlugin.isActive && currentTimerIteration[0] >= maxTimerIterations) {
+                  checkPluginIsReady.cancel()
+
+                  // The Cordova plugin is ready.
+                  PushPlugin.sendExtras(originalExtras)
+                }
+                currentTimerIteration[0] += 1
+              }
+            }, 0, 200)
+          }
+        }
+
       }
     }
   }
@@ -86,12 +163,18 @@ class PushHandlerActivity : Activity() {
 
       extras.getBundle(PushConstants.PUSH_BUNDLE)?.apply {
         putBoolean(PushConstants.FOREGROUND, false)
+        putBoolean(PushConstants.TAPPED, true);
         putBoolean(PushConstants.COLDSTART, !PushPlugin.isActive)
         putBoolean(PushConstants.DISMISSED, extras.getBoolean(PushConstants.DISMISSED))
         putString(
           PushConstants.ACTION_CALLBACK,
           extras.getString(PushConstants.CALLBACK)
         )
+        var notificationsToOpen: String? = ""
+        if (extras.getString(PushConstants.BUNDLE_KEY_OPEN_ALL_NOTIFICATIONS) != null) {
+          notificationsToOpen = extras.getString(PushConstants.BUNDLE_KEY_OPEN_ALL_NOTIFICATIONS)
+        }
+        putString(PushConstants.BUNDLE_KEY_OPEN_ALL_NOTIFICATIONS, notificationsToOpen)
         remove(PushConstants.NO_CACHE)
 
         RemoteInput.getResultsFromIntent(intent)?.let { results ->
@@ -102,8 +185,9 @@ class PushHandlerActivity : Activity() {
           notHaveInlineReply = false
         }
 
-        PushPlugin.sendExtras(this)
       }
+
+      originalExtras =  extras.getBundle(PushConstants.PUSH_BUNDLE)
 
       return notHaveInlineReply
     } ?: true

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -107,6 +107,10 @@ class PushPlugin : CordovaPlugin() {
                 json.put(key, value)
               }
 
+              key == PushConstants.BUNDLE_KEY_OPEN_ALL_NOTIFICATIONS -> {
+                additionalData.put(key, extras.getBoolean(PushConstants.BUNDLE_KEY_OPEN_ALL_NOTIFICATIONS))
+              }
+
               key == PushConstants.COLDSTART -> {
                 additionalData.put(key, extras.getBoolean(PushConstants.COLDSTART))
               }
@@ -464,6 +468,7 @@ class PushPlugin : CordovaPlugin() {
       PushConstants.DELETE_CHANNEL -> executeActionDeleteChannel(data, callbackContext)
       PushConstants.LIST_CHANNELS -> executeActionListChannels(callbackContext)
       PushConstants.CLEAR_NOTIFICATION -> executeActionClearNotification(data, callbackContext)
+      PushConstants.REMOVE_NOTIFICATION_FROM_TRAY_BY_NOTIFICATION_ID -> executeRemoveNotificationFromTray(data, callbackContext)
       PushConstants.CHANGE_DND_FROM_CORES -> executeModifyDNDsettings(data, callbackContext)
       else -> {
         Log.e(TAG, "Execute: Invalid Action $action")

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -111,6 +111,10 @@ class PushPlugin : CordovaPlugin() {
                 additionalData.put(key, extras.getBoolean(PushConstants.BUNDLE_KEY_OPEN_ALL_NOTIFICATIONS))
               }
 
+              key == PushConstants.TAPPED -> {
+                additionalData.put(key, extras.getBoolean(PushConstants.TAPPED))
+              }
+
               key == PushConstants.COLDSTART -> {
                 additionalData.put(key, extras.getBoolean(PushConstants.COLDSTART))
               }

--- a/src/js/push.js
+++ b/src/js/push.js
@@ -339,6 +339,10 @@ module.exports = {
     exec(successCallback, errorCallback, 'PushNotification', 'removeNotificationFromTray', [{notification_id: notification_id}]);
   },
 
+  checkDoNotDisturbPermission: function(successCallback, errorCallback){
+    exec(successCallback, errorCallback, 'PushNotification', 'openDNDsettings', []);
+  },
+
   /**
    * PushNotification Object.
    *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the changes for the following issues:

- Issue #2 : Added logic to request access to the user about modify the DO NOT DISTURB settings of the phone. Once the app has access then it will be able to redirect the user to the phone settings and let him add the "CORES Mobile" app to the exception rule of the phone, giving us the chance to override the sound and vibration settings on the phone when a push notification is received (logic implemented in the issue #6).

- Issue #3 : Added logic to create a notification grouper that will be displayed when there is more than 1 notification displayed in the Notification Drawer. This grouper will remove the existing and the incoming notifications to display a single item with the content of all of them.

- Issue #4 : Added a new function in the plugin to let the CORES Mobile app invoke it to remove notification from the notification drawer by a specific ID. 

- Issue #5 : Modified the listeners used to catch when a notification is received, pressed or dismissed to be able to open the "Inbox Preview" page of the CORES Mobile app and display the content of the notification.

- Issue #6 : Modified the function used to set behavior (sound, vibration and tap behavior) of the push notifications to flex them according to the type of the push notification received. There are 2 types:
     - Normal Notifications. These will have the default behavior of a notification but their vibration and sound will be flexed according to the payload received by Firebase.
     - Critical Notifications. These notification will modify the sound/vibration settings of the phone to ALWAYS be displayed on screen, play a sound and vibrate no matter if the phone is in silent mode or the "Do not disturb" option is enabled. The sound and vibration will be also determined by the payload received by Firebase. The sound settings can be modified in the "Inbox Settings" inside the CORES Mobile app.

Also, this PR includes a fix for the issue #[214](https://github.com/havesource/cordova-plugin-push/issues/214) of the original repository of this plugin: Fixes the white icon displayed in the notification drawer when a push notification is received and displayed in the phone. Since there is no default icon, we are using the CORES Mobile icon that was added in the Android project when it is compilated.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/TransformativeMed/cordova-plugin-push/issues/2
https://github.com/TransformativeMed/cordova-plugin-push/issues/3
https://github.com/TransformativeMed/cordova-plugin-push/issues/4
https://github.com/TransformativeMed/cordova-plugin-push/issues/5
https://github.com/TransformativeMed/cordova-plugin-push/issues/6

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
These changes are a result of the features requested by T4M.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
These changes were tested using a real device with the following specs:
- Device: Pixel 6a
- Android version: 13

## Screenshots (if appropriate):

- Issue #2 : 

     - Request access to the DND settings of the phone when the app is opened.

https://github.com/TransformativeMed/cordova-plugin-push/assets/12654157/89273c1e-8130-4632-a41f-38c9181e3dcc

     - Open the DND settings from the Inbox settings of the CORES Mobile app.

https://github.com/TransformativeMed/cordova-plugin-push/assets/12654157/b4dc2cee-0901-492c-9074-8fe5a6958329

- Issue #3 : 

     - When the phone receives a notification and the notification drawer is empty.

https://github.com/TransformativeMed/cordova-plugin-push/assets/12654157/49d087d0-7602-4ab3-8ba8-0c14e7dcdbee

     - When the notification drawer has an item and new notifications are received.

https://github.com/TransformativeMed/cordova-plugin-push/assets/12654157/5a9305e5-295c-4e8e-b249-85da404dafd5

https://github.com/TransformativeMed/cordova-plugin-push/assets/12654157/66e4afe1-c6a2-4d01-a8bf-984d2eac5dd7

- Issue #4 : 

     - Remove a single notification from the notification drawer when the reminder that belongs to that notification is opened in the CORES Mobile app:

https://github.com/TransformativeMed/cordova-plugin-push/assets/12654157/d04a4a01-344b-4454-a8ca-20cad0e283a5


     - Remove the notification opened in the CORES Mobile app from the notification grouper.

https://github.com/TransformativeMed/cordova-plugin-push/assets/12654157/e83bda3c-2c2c-4152-b01c-0bed5c75cc59

- Issue #5 :

     - Tapped a single/grouped notification when the app is in:
          - Foreground: The user will be redirected to the Inbox page.

https://github.com/TransformativeMed/cordova-plugin-push/assets/12654157/edab6e85-26f9-4c8f-b2b4-0c38d15daa76

          - Background: The app will be returned to foreground and the user will be redirected to the Inbox page.

https://github.com/TransformativeMed/cordova-plugin-push/assets/12654157/64252807-6409-4d5a-a008-b7ee74ccab1e



          - Closed: The app will be closed and the "Inbox Preview" page will be displayed to render the content of the pressed notification.

https://github.com/TransformativeMed/cordova-plugin-push/assets/12654157/55b25c39-cc24-497a-8109-40b99fabac73

https://github.com/TransformativeMed/cordova-plugin-push/assets/12654157/672af81d-3bdc-4a37-8401-d0fd4139f132

- Issue #6 : 
     
     - Normal notification with flexed sounds:

https://github.com/TransformativeMed/cordova-plugin-push/assets/12654157/f956d478-b749-407b-b1f6-0add1832f2ad


     - Critical notification (pending video).
     

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
